### PR TITLE
Statutes: Change domicile to Zug

### DIFF
--- a/statutes.md
+++ b/statutes.md
@@ -2,7 +2,7 @@
 
 Pursuant to Articles 60 et sqq. Civil Code (Zivilgesetzbuch) an association is
 organized under the name „Bitcoin Association Switzerland“ (hereinafter the
-“Association”) with its domicile in Zurich.
+“Association”) with its domicile in Zug.
 
 ## Art. 1 Objective
 


### PR DESCRIPTION
Zug has lower taxes and is more Bitcoin-friendly than Zürich. It's also way easier to deal with the Zug government than with the Zurich government.